### PR TITLE
Implementado set para AFG3021B

### DIFF
--- a/software/python/basicos.py
+++ b/software/python/basicos.py
@@ -24,7 +24,7 @@ xs = []
 ys = []
 for n in range(5, 10):
     xs.append(n)
-    ys.append(n * n)
+    ys.append(n * n) # camobio rápido
 
 print('El largo de la lista es:')
 print(len(xs))

--- a/software/python/instrumentos/TektronixAFG3021B.py
+++ b/software/python/instrumentos/TektronixAFG3021B.py
@@ -30,8 +30,9 @@ class AFG3021B:
     def getFrequency(self):
         return self._generador.query_ascii_values('FREQ?')
         
-    def setAmplitude(self, freq):
-        print('falta')
+    def setAmplitude(self, amp):
+        self._generador.write(f'SOURce1:VOLTage:LEVel:IMMediate:AMPLitude {amp}V') 
+        
         
     def getAmplitude(self):
         print('falta')

--- a/test_pull_request.md
+++ b/test_pull_request.md
@@ -1,0 +1,1 @@
+Esta es una prueba de un pull request

--- a/test_pull_request.md
+++ b/test_pull_request.md
@@ -1,1 +1,4 @@
-Esta es una prueba de un pull request
+Esta es una prueba de un pull request.
+
+
+Esto es un modificación.


### PR DESCRIPTION
No estaba implementada la funcionalidad de setear la amplitud de salida del generador de funciones AFG3021. En este commit está implementado.